### PR TITLE
Fix error in model_search.py and add architecture paramater to torch paramrters

### DIFF
--- a/auto_deeplab.py
+++ b/auto_deeplab.py
@@ -9,7 +9,7 @@ from operations import *
 
 class AutoDeeplab (nn.Module) :
 
-    def __init__(self, num_classes, num_layers, criterion, num_channel = 40, multiplier = 5, step = 5, crop_size, cell=model_search.Cell):
+    def __init__(self, num_classes, num_layers, criterion, num_channel = 40, multiplier = 5, step = 5, crop_size=None, cell=model_search.Cell):
         super(AutoDeeplab, self).__init__()
         self.cells = nn.ModuleList()
         self._num_layers = num_layers
@@ -19,6 +19,7 @@ class AutoDeeplab (nn.Module) :
         self._num_channel = num_channel
         self._criterion = criterion
         self._crop_size = crop_size
+        self._arch_param_names = ["alphas_cell", "alphas_network"]
         self._initialize_alphas ()
         self.stem0 = nn.Sequential(
             nn.Conv2d(3, 64, 3, stride=2, padding=1),
@@ -333,12 +334,14 @@ class AutoDeeplab (nn.Module) :
     def _initialize_alphas(self):
         k = sum(1 for i in range(self._step) for n in range(2+i))
         num_ops = len(PRIMITIVES)
-        self.alphas_cell = torch.tensor (1e-3*torch.randn(k, num_ops).cuda(), requires_grad=True)
-        self.alphas_network = torch.tensor (1e-3*torch.randn(self._num_layers, 4, 3).cuda(), requires_grad=True)
-        self._arch_parameters = [
-            self.alphas_cell,
-            self.alphas_network
-        ]
+        alphas_cell = torch.tensor (1e-3*torch.randn(k, num_ops).cuda(), requires_grad=True)
+        self.register_parameter(self._arch_param_names[0], nn.Parameter(alphas_cell))
+
+        # num_layer x num_spatial_levels x num_spatial_connections (down, level, up)
+        alphas_network = torch.tensor (1e-3*torch.randn(self._num_layers, 4, 3).cuda(), requires_grad=True)
+        self.register_parameter(self._arch_param_names[1], nn.Parameter(alphas_network))
+        self.alphas_network_mask = torch.ones(self._num_layers, 4, 3)
+
 
     def decode_network (self) :
         best_result = []
@@ -533,11 +536,11 @@ class AutoDeeplab (nn.Module) :
         print (max_prop)
         return best_result
 
+    def arch_parameters(self):
+        return [param for name, param in self.named_parameters() if name in self._arch_param_names]
 
-
-
-    def arch_parameters (self) :
-        return self._arch_parameters
+    def weight_parameters(self):
+        return [param for name, param in self.named_parameters() if name not in self._arch_param_names]
 
     def genotype(self):
         def _parse(weights):

--- a/train_autodeeplab.py
+++ b/train_autodeeplab.py
@@ -48,7 +48,7 @@ class Trainer(object):
         # Define network
         model = AutoDeeplab (self.nclass, 12, self.criterion, crop_size=self.args.crop_size)
         optimizer = torch.optim.SGD(
-                model.parameters(),
+                model.weight_parameters(),
                 args.lr,
                 momentum=args.momentum,
                 weight_decay=args.weight_decay

--- a/train_autodeeplab.py
+++ b/train_autodeeplab.py
@@ -250,9 +250,8 @@ def main():
     # cuda, seed and logging
     parser.add_argument('--no_cuda', action='store_true', default=
                         False, help='disables CUDA training')
-    parser.add_argument('--gpu_ids', type=str, default='0',
-                        help='use which gpu to train, must be a \
-                        comma-separated list of integers only (default=0)')
+    parser.add_argument('--gpu-ids', nargs='*', type=int, default=0,
+                        help='which GPU to train on (default: 0)')
     parser.add_argument('--seed', type=int, default=1, metavar='S',
                         help='random seed (default: 1)')
     # checking point
@@ -271,11 +270,6 @@ def main():
 
     args = parser.parse_args()
     args.cuda = not args.no_cuda and torch.cuda.is_available()
-    if args.cuda:
-        try:
-            args.gpu_ids = [int(s) for s in args.gpu_ids.split(',')]
-        except ValueError:
-            raise ValueError('Argument --gpu_ids must be a comma-separated list of integers only')
 
     if args.sync_bn is None:
         if args.cuda and len(args.gpu_ids) > 1:


### PR DESCRIPTION
There was a mistake in `model_search.py` This should be resolved with this fix.

The problem was that some network cell use `None` as an input. For such cells the cell architecture weights did not align the same as for cells with to valid inputs. This cause a discrepancy in training. The cell weight should always align for the same operation and connection throughout the network.

Would be great if you can review this change and give me feedback if it has an impact on the performance.